### PR TITLE
Changes to the library

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,6 @@ include = [
 
 [lib]
 crate-type = ["cdylib"]
+
+[dependencies]
+thiserror = "1.0.57"


### PR DESCRIPTION
# Motivation
This is the first crate that shows up when you search for "Rust DNI crate". It should be high quality.

# Changes
## `Error` enum
- This PR introduces the `thiserror` crate to provide an idiomatic way to return errors. I assume that the author comes from a golang background but in Rust we have other patterns.
- This allows the users of the crate to use the errors in a more fine-grained way while also having the a default display.
- All of the exported functions now return a Result with this.
## Refactors
Changed some patterns so that they are more rust-like